### PR TITLE
feat: TextInput 컴포넌트 구현

### DIFF
--- a/src/app/_components/TextInput/index.tsx
+++ b/src/app/_components/TextInput/index.tsx
@@ -1,0 +1,48 @@
+import { ComponentPropsWithoutRef, forwardRef } from 'react';
+
+import { VariantProps, cva } from 'class-variance-authority';
+
+import { cn } from '@/src/utils/cn';
+
+const textInputCSS = cva(
+  'w-full rounded-lg border-2 p-3 placeholder-gray-500 outline-none',
+  {
+    variants: {
+      variant: {
+        default: 'border-gray-300 bg-transparent ',
+        filled: 'border-gray-200 bg-gray-200 ',
+        underline:
+          'rounded-none border-0 border-b-2 border-gray-300 bg-transparent',
+        error: 'ring-2 ring-red-500',
+      },
+      isDisabled: {
+        false: '',
+        true: 'bg-gray-accent7 placeholder-gray-accent3 cursor-not-allowed',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      isDisabled: false,
+    },
+  },
+);
+
+type TextInputProps = ComponentPropsWithoutRef<'input'> &
+  VariantProps<typeof textInputCSS>;
+
+const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
+  ({ variant, className, ...props }, ref) => {
+    const { disabled: isDisabled } = props;
+
+    return (
+      <input
+        ref={ref}
+        className={cn(textInputCSS({ variant, isDisabled }), className)}
+        {...props}
+      />
+    );
+  },
+);
+
+TextInput.displayName = 'TextInput';
+export default TextInput;


### PR DESCRIPTION
## 💬 Issue Number

> closes #23 

## 🤷‍♂️ Description

> 작업 내용에 대한 설명
TextInput 컴포넌트 구현했습니다.
디자인이 확정되지 않아서 아래 이미지 정도로 구현했습니다. 
불필요하거나 추가해야하는 사항이 있다면 말씀해주세요:)

## 📷 Screenshots
> 작업 결과물
![image](https://github.com/nodak-v2/Nodak-FE/assets/107539614/795792c4-d556-42ea-ae74-92d4a45909f7)
## 👻 Good Function

> 팀원에게 공유하고 싶은 함수나 코드 일부

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점 특이사항
textInput 컴포넌트에 fowardRef를 사용하면서 다음메세지의 eslint 에러가 발생했습니다. 
`Component definition is missing display name`
리액트 컴포넌트 이름이 있어야한다는 eslint 규칙에서 발생한 경고인데 displayName 속성을 설정해서 문제를 해결할 수 있었습니다. 
-> `TextInput.displayName = 'TextInput';` 코드 추가 해결

## 📋 Check List

> PR 전 체크해주세요.

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] 코딩컨벤션을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?

## 📒 Remarks

현재 pr에서 class-variance-authority 설치가 안돼서 빌드가 안되는 거 같습니다. 
이전 class-variance-authority 설치했던 pr이 머지되면 pull한 후 머지해야할 거 같습니다.
