### PR TITLE
[#33] Feat: 유저 목록 페이지 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react": "^18",
     "react-dom": "^18",
     "swiper": "^11.1.1",
-    "tailwind-merge": "^2.2.1"
+    "tailwind-merge": "^2.2.1",
+    "vaul": "^0.9.0"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^1.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ dependencies:
   tailwind-merge:
     specifier: ^2.2.1
     version: 2.2.2
+  vaul:
+    specifier: ^0.9.0
+    version: 0.9.0(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
 
 devDependencies:
   '@chromatic-com/storybook':
@@ -2319,6 +2322,12 @@ packages:
       webpack: 5.91.0(esbuild@0.20.2)
     dev: true
 
+  /@radix-ui/primitive@1.0.1:
+    resolution: {integrity: sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==}
+    dependencies:
+      '@babel/runtime': 7.24.4
+    dev: false
+
   /@radix-ui/react-compose-refs@1.0.1(@types/react@18.2.79)(react@18.2.0):
     resolution: {integrity: sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==}
     peerDependencies:
@@ -2331,7 +2340,195 @@ packages:
       '@babel/runtime': 7.24.4
       '@types/react': 18.2.79
       react: 18.2.0
-    dev: true
+
+  /@radix-ui/react-context@1.0.1(@types/react@18.2.79)(react@18.2.0):
+    resolution: {integrity: sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.4
+      '@types/react': 18.2.79
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-dialog@1.0.5(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-GjWJX/AUpB703eEBanuBnIWdIXg6NvJFCXcNlSZk4xdszCdhrJgBoUd1cGk67vFO+WdA2pfI/plOpqz/5GUP6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.4
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.0.5(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-focus-scope': 1.0.4(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-portal': 1.0.4(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.79)(react@18.2.0)
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+      aria-hidden: 1.2.4
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-remove-scroll: 2.5.5(@types/react@18.2.79)(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-dismissable-layer@1.0.5(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-aJeDjQhywg9LBu2t/At58hCvr7pEm0o2Ke1x33B+MhjNmmZ17sy4KImo0KPLgsnc/zN7GPdce8Cnn0SWvwZO7g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.4
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-use-escape-keydown': 1.0.3(@types/react@18.2.79)(react@18.2.0)
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-focus-guards@1.0.1(@types/react@18.2.79)(react@18.2.0):
+    resolution: {integrity: sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.4
+      '@types/react': 18.2.79
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-focus-scope@1.0.4(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-sL04Mgvf+FmyvZeYfNu1EPAaaxD+aw7cYeIB9L9Fvq8+urhltTRaEo5ysKOpHuKPclsZcSUMKlN05x4u+CINpA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.4
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.79)(react@18.2.0)
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-id@1.0.1(@types/react@18.2.79)(react@18.2.0):
+    resolution: {integrity: sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.4
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.79)(react@18.2.0)
+      '@types/react': 18.2.79
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-portal@1.0.4(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-Qki+C/EuGUVCQTOTD5vzJzJuMUlewbzuKyUy+/iHM2uwGiru9gZeBJtHAPKAEkB5KWGi9mP/CHKcY0wt1aW45Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.4
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-presence@1.0.1(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.4
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.79)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.79)(react@18.2.0)
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-primitive@1.0.3(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.4
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.79)(react@18.2.0)
+      '@types/react': 18.2.79
+      '@types/react-dom': 18.2.25
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
 
   /@radix-ui/react-slot@1.0.2(@types/react@18.2.79)(react@18.2.0):
     resolution: {integrity: sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==}
@@ -2346,7 +2543,64 @@ packages:
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.79)(react@18.2.0)
       '@types/react': 18.2.79
       react: 18.2.0
-    dev: true
+
+  /@radix-ui/react-use-callback-ref@1.0.1(@types/react@18.2.79)(react@18.2.0):
+    resolution: {integrity: sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.4
+      '@types/react': 18.2.79
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-use-controllable-state@1.0.1(@types/react@18.2.79)(react@18.2.0):
+    resolution: {integrity: sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.4
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.79)(react@18.2.0)
+      '@types/react': 18.2.79
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-use-escape-keydown@1.0.3(@types/react@18.2.79)(react@18.2.0):
+    resolution: {integrity: sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.4
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.2.79)(react@18.2.0)
+      '@types/react': 18.2.79
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-use-layout-effect@1.0.1(@types/react@18.2.79)(react@18.2.0):
+    resolution: {integrity: sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.4
+      '@types/react': 18.2.79
+      react: 18.2.0
+    dev: false
 
   /@rushstack/eslint-patch@1.10.2:
     resolution: {integrity: sha512-hw437iINopmQuxWPSUEvqE56NCPsiU8N4AYtfHmJFckclktzK9YQJieD3XkDCDH4OjL+C7zgPUh73R/nrcHrqw==}
@@ -3677,7 +3931,6 @@ packages:
 
   /@types/prop-types@15.7.12:
     resolution: {integrity: sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==}
-    dev: true
 
   /@types/qs@6.9.15:
     resolution: {integrity: sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==}
@@ -3691,14 +3944,12 @@ packages:
     resolution: {integrity: sha512-o/V48vf4MQh7juIKZU2QGDfli6p1+OOi5oXx36Hffpc9adsHeXjVp8rHuPkjd8VT8sOJ2Zp05HR7CdpGTIUFUA==}
     dependencies:
       '@types/react': 18.2.79
-    dev: true
 
   /@types/react@18.2.79:
     resolution: {integrity: sha512-RwGAGXPl9kSXwdNTafkOEuFrTBD5SA2B3iEB96xi8+xu5ddUa/cpvyVCSNn+asgLCTHkb5ZxN8gbuibYJi4s1w==}
     dependencies:
       '@types/prop-types': 15.7.12
       csstype: 3.1.3
-    dev: true
 
   /@types/resolve@1.20.6:
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
@@ -4320,6 +4571,13 @@ packages:
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
     dev: true
+
+  /aria-hidden@1.2.4:
+    resolution: {integrity: sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==}
+    engines: {node: '>=10'}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
 
   /aria-query@5.1.3:
     resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
@@ -5437,7 +5695,6 @@ packages:
 
   /csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
-    dev: true
 
   /damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -5655,6 +5912,10 @@ packages:
     resolution: {integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==}
     engines: {node: '>=8'}
     dev: true
+
+  /detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+    dev: false
 
   /detect-package-manager@2.0.1:
     resolution: {integrity: sha512-j/lJHyoLlWi6G1LDdLgvUtz60Zo5GEj+sVYtTVXnYLDPuzgC3llMxonXym9zIwhhUII8vjdw0LXxavpLqTbl1A==}
@@ -6932,6 +7193,11 @@ packages:
       hasown: 2.0.2
     dev: true
 
+  /get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
+    dev: false
+
   /get-npm-tarball-url@2.1.0:
     resolution: {integrity: sha512-ro+DiMu5DXgRBabqXupW38h7WPZ9+Ad8UjwhvsmmN8w1sU7ab0nzAXvVZ4kqYg57OrqomRtJvepX5/xvFKNtjA==}
     engines: {node: '>=12.17'}
@@ -7399,6 +7665,12 @@ packages:
       hasown: 2.0.2
       side-channel: 1.0.6
     dev: true
+
+  /invariant@2.2.4:
+    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+    dependencies:
+      loose-envify: 1.4.0
+    dev: false
 
   /ip@2.0.1:
     resolution: {integrity: sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==}
@@ -9553,6 +9825,58 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /react-remove-scroll-bar@2.3.6(@types/react@18.2.79)(react@18.2.0):
+    resolution: {integrity: sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.2.79
+      react: 18.2.0
+      react-style-singleton: 2.2.1(@types/react@18.2.79)(react@18.2.0)
+      tslib: 2.6.2
+    dev: false
+
+  /react-remove-scroll@2.5.5(@types/react@18.2.79)(react@18.2.0):
+    resolution: {integrity: sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.2.79
+      react: 18.2.0
+      react-remove-scroll-bar: 2.3.6(@types/react@18.2.79)(react@18.2.0)
+      react-style-singleton: 2.2.1(@types/react@18.2.79)(react@18.2.0)
+      tslib: 2.6.2
+      use-callback-ref: 1.3.2(@types/react@18.2.79)(react@18.2.0)
+      use-sidecar: 1.1.2(@types/react@18.2.79)(react@18.2.0)
+    dev: false
+
+  /react-style-singleton@2.2.1(@types/react@18.2.79)(react@18.2.0):
+    resolution: {integrity: sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.2.79
+      get-nonce: 1.0.1
+      invariant: 2.2.4
+      react: 18.2.0
+      tslib: 2.6.2
+    dev: false
+
   /react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
     engines: {node: '>=0.10.0'}
@@ -11024,6 +11348,37 @@ packages:
       qs: 6.12.1
     dev: true
 
+  /use-callback-ref@1.3.2(@types/react@18.2.79)(react@18.2.0):
+    resolution: {integrity: sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.2.79
+      react: 18.2.0
+      tslib: 2.6.2
+    dev: false
+
+  /use-sidecar@1.1.2(@types/react@18.2.79)(react@18.2.0):
+    resolution: {integrity: sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^16.9.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.2.79
+      detect-node-es: 1.1.0
+      react: 18.2.0
+      tslib: 2.6.2
+    dev: false
+
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
@@ -11063,6 +11418,20 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
     dev: true
+
+  /vaul@0.9.0(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-bZSySGbAHiTXmZychprnX/dE0EsSige88xtyyL3/MCRbrFotRPQZo7UdydGXZWw+CKbNOw5Ow8gwAo93/nB/Cg==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    dependencies:
+      '@radix-ui/react-dialog': 1.0.5(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+    dev: false
 
   /vm-browserify@1.1.2:
     resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,6 +24,10 @@
   }
 }
 
-ul > li:last-child {
+ul > button:last-child {
   border-bottom: none;
+}
+
+#drawer-content::after {
+  content: none;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -23,3 +23,7 @@
     --dark-2: #212529;
   }
 }
+
+ul > li:last-child {
+  border-bottom: none;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,7 @@ const RootLayout = ({
             </div>
             <div
               id='layout-Root'
-              className='relative flex h-full max-h-[950px] min-h-[600px] w-full min-w-[350px] max-w-[450px] shrink-0 flex-col shadow-xl'
+              className='relative flex h-full max-h-[950px] min-h-[600px] w-full min-w-[350px] max-w-[450px] shrink-0 flex-col bg-dark-accent2 shadow-xl'
             >
               {children}
             </div>

--- a/src/app/users/_components/DrawerButton.tsx
+++ b/src/app/users/_components/DrawerButton.tsx
@@ -2,35 +2,30 @@
 
 import Link from 'next/link';
 
-interface DrawerButtonProps {
-  isMe?: boolean;
-}
-const DrawerButton = ({ isMe = true }: DrawerButtonProps) => {
+export const LinkProfileButton = () => (
+  <Link href='/profile' className='w-full rounded-md bg-dark-accent1 px-4 py-2'>
+    <button className='w-full text-sm text-gray-accent1'>프로필 조회</button>
+  </Link>
+);
+
+export const LinkDMButton = () => (
+  <Link href='/chat' className='w-full rounded-md bg-dark-accent1 px-4 py-2'>
+    <button className='w-full text-sm text-gray-accent1'>메시지 보내기</button>
+  </Link>
+);
+
+export const FollowButton = () => {
+  const handleFollow = () => {
+    console.log('팔로우');
+    // 팔로우 로직
+  };
+
   return (
-    isMe && (
-      <div className='flex items-center gap-4'>
-        <Link
-          href='/chat'
-          className='w-full rounded-md bg-dark-accent1 px-4 py-2'
-        >
-          <button className='w-full text-sm text-gray-accent1'>
-            메시지 보내기
-          </button>
-        </Link>
-        <Link
-          href='/profile'
-          className='w-full rounded-md bg-dark-accent1 px-4 py-2'
-        >
-          <button className='w-full text-sm text-gray-accent1'>
-            프로필 조회
-          </button>
-        </Link>
-        <button className='w-full rounded-md bg-dark-accent1 px-4 py-2 text-sm text-gray-accent1'>
-          팔로우
-        </button>
-      </div>
-    )
+    <button
+      className='w-full rounded-md bg-dark-accent1 px-4 py-2.5 text-sm text-gray-accent1'
+      onClick={handleFollow}
+    >
+      팔로우
+    </button>
   );
 };
-
-export default DrawerButton;

--- a/src/app/users/_components/DrawerButton.tsx
+++ b/src/app/users/_components/DrawerButton.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import Link from 'next/link';
+
+interface DrawerButtonProps {
+  isMe?: boolean;
+}
+const DrawerButton = ({ isMe = true }: DrawerButtonProps) => {
+  return (
+    isMe && (
+      <div className='flex items-center gap-4'>
+        <Link
+          href='/chat'
+          className='w-full rounded-md bg-dark-accent1 px-4 py-2'
+        >
+          <button className='w-full text-sm text-gray-accent1'>
+            메시지 보내기
+          </button>
+        </Link>
+        <Link
+          href='/profile'
+          className='w-full rounded-md bg-dark-accent1 px-4 py-2'
+        >
+          <button className='w-full text-sm text-gray-accent1'>
+            프로필 조회
+          </button>
+        </Link>
+        <button className='w-full rounded-md bg-dark-accent1 px-4 py-2 text-sm text-gray-accent1'>
+          팔로우
+        </button>
+      </div>
+    )
+  );
+};
+
+export default DrawerButton;

--- a/src/app/users/_components/DrawerContent.tsx
+++ b/src/app/users/_components/DrawerContent.tsx
@@ -1,0 +1,51 @@
+import Image from 'next/image';
+
+import { DrawerClose, DrawerContent } from '@/src/components/ui/Drawer';
+
+import { FollowButton, LinkDMButton, LinkProfileButton } from './DrawerButton';
+
+interface DrawerContentBoxProps {
+  image?: string;
+  name: string;
+  isMe?: boolean;
+}
+
+const DrawerContentBox = ({
+  image = 'https://via.placeholder.com/150',
+  name,
+  isMe = false,
+}: DrawerContentBoxProps) => (
+  <DrawerContent
+    id='drawer-content'
+    className='absolute bottom-0 border-none bg-dark-accent1 text-gray-accent1'
+  >
+    <li className='flex flex-col gap-4 p-4'>
+      <Image
+        src={image}
+        alt='유저 아바타'
+        width={80}
+        height={80}
+        className='rounded-full object-contain'
+      />
+      <div className='flex flex-col gap-4 rounded-md bg-dark-accent2 p-4'>
+        <div className='text-lg font-bold'>{name}</div>
+        <div className='flex items-center gap-3'>
+          {isMe ? (
+            <LinkProfileButton />
+          ) : (
+            <>
+              <LinkProfileButton />
+              <LinkDMButton />
+              <FollowButton />
+            </>
+          )}
+        </div>
+      </div>
+    </li>
+    <DrawerClose className='rounded-b-md bg-dark-accent2 py-2 text-gray-accent1'>
+      닫기
+    </DrawerClose>
+  </DrawerContent>
+);
+
+export default DrawerContentBox;

--- a/src/app/users/_components/UserItem.tsx
+++ b/src/app/users/_components/UserItem.tsx
@@ -1,5 +1,12 @@
 import Image from 'next/image';
 
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerTrigger,
+} from '@/src/components/ui/Drawer';
+
 interface User {
   id: number;
   name: string;
@@ -12,34 +19,37 @@ interface UserItemProps {
 }
 
 const UserItem = ({ user }: UserItemProps) => {
-  const { id, name, userImage } = user;
+  const { name, userImage } = user;
 
   return (
-    <li
-      key={`${id}-${name}`}
-      className='flex items-center gap-4 border-b border-gray-accent2 p-3'
-    >
-      <Image
-        src={userImage}
-        alt='유저아바타'
-        width={40}
-        height={40}
-        className='rounded-full'
-      />
-      <span className='text-gray-accent1'>{id}</span>
-    </li>
+    <Drawer>
+      <DrawerTrigger className='flex w-full items-center gap-4 border-b border-gray-accent2 p-3'>
+        <Image
+          src={userImage}
+          alt='유저아바타'
+          width={40}
+          height={40}
+          className='rounded-full'
+        />
+        <span className='text-gray-accent1'>{`${name}`}</span>
+      </DrawerTrigger>
+      <DrawerContent className='absolute'>
+        <div className='p-4'>
+          <span className='text-lg font-bold text-white'>{name}</span>
+        </div>
+        <DrawerClose className='text-gray-accent1'>닫기</DrawerClose>
+      </DrawerContent>
+    </Drawer>
   );
 };
 
 const UserList = ({ users }: { users: User[] }) => {
   return (
-    <>
-      <ul className='rounded-md bg-dark-accent1'>
-        {users.map(user => (
-          <UserItem key={`${user.id}-${user.name}`} user={user} />
-        ))}
-      </ul>
-    </>
+    <ul className='rounded-md bg-dark-accent1'>
+      {users.map(user => (
+        <UserItem key={`${user.id}-${user.name}`} user={user} />
+      ))}
+    </ul>
   );
 };
 

--- a/src/app/users/_components/UserItem.tsx
+++ b/src/app/users/_components/UserItem.tsx
@@ -7,6 +7,8 @@ import {
   DrawerTrigger,
 } from '@/src/components/ui/Drawer';
 
+import DrawerButton from './DrawerButton';
+
 interface User {
   id: number;
   name: string;
@@ -33,11 +35,26 @@ const UserItem = ({ user }: UserItemProps) => {
         />
         <span className='text-gray-accent1'>{`${name}`}</span>
       </DrawerTrigger>
-      <DrawerContent className='absolute'>
-        <div className='p-4'>
-          <span className='text-lg font-bold text-white'>{name}</span>
+      <DrawerContent
+        id='drawer-content'
+        className='absolute bottom-0 border-none bg-dark-accent1 text-gray-accent1'
+      >
+        <div className='flex flex-col gap-8 p-4'>
+          <Image
+            src={userImage}
+            alt='유저 아바타'
+            width={80}
+            height={80}
+            className='object-fit rounded-full'
+          />
+          <div className='flex flex-col gap-4 rounded-md bg-dark-accent2 p-4 pt-2'>
+            <div className='text-lg font-bold text-gray-accent1'>{name}</div>
+            <DrawerButton isMe={true} />
+          </div>
         </div>
-        <DrawerClose className='text-gray-accent1'>닫기</DrawerClose>
+        <DrawerClose className='rounded-b-md bg-dark-accent2 py-2 text-gray-accent1'>
+          닫기
+        </DrawerClose>
       </DrawerContent>
     </Drawer>
   );

--- a/src/app/users/_components/UserItem.tsx
+++ b/src/app/users/_components/UserItem.tsx
@@ -1,0 +1,46 @@
+import Image from 'next/image';
+
+interface User {
+  id: number;
+  name: string;
+  userImage: string;
+  isOnline: boolean;
+}
+
+interface UserItemProps {
+  user: User;
+}
+
+const UserItem = ({ user }: UserItemProps) => {
+  const { id, name, userImage } = user;
+
+  return (
+    <li
+      key={`${id}-${name}`}
+      className='flex items-center gap-4 border-b border-gray-accent2 p-3'
+    >
+      <Image
+        src={userImage}
+        alt='유저아바타'
+        width={40}
+        height={40}
+        className='rounded-full'
+      />
+      <span className='text-gray-accent1'>{id}</span>
+    </li>
+  );
+};
+
+const UserList = ({ users }: { users: User[] }) => {
+  return (
+    <>
+      <ul className='rounded-md bg-dark-accent1'>
+        {users.map(user => (
+          <UserItem key={`${user.id}-${user.name}`} user={user} />
+        ))}
+      </ul>
+    </>
+  );
+};
+
+export default UserList;

--- a/src/app/users/_components/UserList.tsx
+++ b/src/app/users/_components/UserList.tsx
@@ -1,13 +1,8 @@
 import Image from 'next/image';
 
-import {
-  Drawer,
-  DrawerClose,
-  DrawerContent,
-  DrawerTrigger,
-} from '@/src/components/ui/Drawer';
+import { Drawer, DrawerTrigger } from '@/src/components/ui/Drawer';
 
-import DrawerButton from './DrawerButton';
+import DrawerContent from './DrawerContent';
 
 interface User {
   id: number;
@@ -33,41 +28,19 @@ const UserItem = ({ user }: UserItemProps) => {
           height={40}
           className='rounded-full'
         />
-        <span>{`${name}`}</span>
+        <span>{name}</span>
       </DrawerTrigger>
-      <DrawerContent
-        id='drawer-content'
-        className='absolute bottom-0 border-none bg-dark-accent1 text-gray-accent1'
-      >
-        <li className='flex flex-col gap-8 p-4'>
-          <Image
-            src={userImage}
-            alt='유저 아바타'
-            width={80}
-            height={80}
-            className='object-fit rounded-full'
-          />
-          <div className='flex flex-col gap-4 rounded-md bg-dark-accent2 p-4 pt-2'>
-            <div className='text-lg font-bold'>{name}</div>
-            <DrawerButton isMe={true} />
-          </div>
-        </li>
-        <DrawerClose className='rounded-b-md bg-dark-accent2 py-2 text-gray-accent1'>
-          닫기
-        </DrawerClose>
-      </DrawerContent>
+      <DrawerContent image={userImage} name={name} />
     </Drawer>
   );
 };
 
-const UserList = ({ users }: { users: User[] }) => {
-  return (
-    <ul className='rounded-md bg-dark-accent1'>
-      {users.map(user => (
-        <UserItem key={`${user.id}-${user.name}`} user={user} />
-      ))}
-    </ul>
-  );
-};
+const UserList = ({ users }: { users: User[] }) => (
+  <ul className='rounded-md bg-dark-accent1'>
+    {users.map(user => (
+      <UserItem key={`${user.id}-${user.name}`} user={user} />
+    ))}
+  </ul>
+);
 
 export default UserList;

--- a/src/app/users/_components/UserList.tsx
+++ b/src/app/users/_components/UserList.tsx
@@ -33,13 +33,13 @@ const UserItem = ({ user }: UserItemProps) => {
           height={40}
           className='rounded-full'
         />
-        <span className='text-gray-accent1'>{`${name}`}</span>
+        <span>{`${name}`}</span>
       </DrawerTrigger>
       <DrawerContent
         id='drawer-content'
         className='absolute bottom-0 border-none bg-dark-accent1 text-gray-accent1'
       >
-        <div className='flex flex-col gap-8 p-4'>
+        <li className='flex flex-col gap-8 p-4'>
           <Image
             src={userImage}
             alt='유저 아바타'
@@ -48,10 +48,10 @@ const UserItem = ({ user }: UserItemProps) => {
             className='object-fit rounded-full'
           />
           <div className='flex flex-col gap-4 rounded-md bg-dark-accent2 p-4 pt-2'>
-            <div className='text-lg font-bold text-gray-accent1'>{name}</div>
+            <div className='text-lg font-bold'>{name}</div>
             <DrawerButton isMe={true} />
           </div>
-        </div>
+        </li>
         <DrawerClose className='rounded-b-md bg-dark-accent2 py-2 text-gray-accent1'>
           닫기
         </DrawerClose>

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -1,5 +1,5 @@
 import GNB from '../_components/GNB';
-import UserList from './_components/UserItem';
+import UserList from './_components/UserList';
 
 const UserListPageDummyData = [
   {
@@ -47,8 +47,8 @@ const UserListPageDummyData = [
 ];
 
 const UserListPage = () => {
-  const isOnlineUser = UserListPageDummyData.filter(user => user.isOnline);
-  const isOfflineUser = UserListPageDummyData.filter(user => !user.isOnline);
+  const onLineUsers = UserListPageDummyData.filter(user => user.isOnline);
+  const offLineUsers = UserListPageDummyData.filter(user => !user.isOnline);
 
   return (
     <>
@@ -56,13 +56,13 @@ const UserListPage = () => {
         TobBar자리
       </div>
       <div className='flex grow flex-col gap-4 p-4'>
-        <div className='flex flex-col gap-2'>
-          <span className='text-gray-accent1'>{`온라인-${isOnlineUser.length}`}</span>
-          <UserList users={isOnlineUser} />
+        <div className='flex flex-col gap-2 text-gray-accent1'>
+          <span>{`온라인-${onLineUsers.length}`}</span>
+          <UserList users={onLineUsers} />
         </div>
-        <div className='flex flex-col gap-2'>
-          <span className='text-gray-accent2'>{`오프라인-${isOfflineUser.length}`}</span>
-          <UserList users={isOfflineUser} />
+        <div className='flex flex-col gap-2 text-gray-accent2'>
+          <span>{`오프라인-${offLineUsers.length}`}</span>
+          <UserList users={offLineUsers} />
         </div>
       </div>
       <GNB />

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -1,0 +1,73 @@
+import GNB from '../_components/GNB';
+import UserList from './_components/UserItem';
+
+const UserListPageDummyData = [
+  {
+    id: 1,
+    name: 'Alice',
+    isOnline: true,
+    userImage: 'https://via.placeholder.com/150',
+  },
+  {
+    id: 2,
+    name: 'Bob',
+    isOnline: false,
+    userImage: 'https://via.placeholder.com/150',
+  },
+  {
+    id: 3,
+    name: 'Charlie',
+    isOnline: true,
+    userImage: 'https://via.placeholder.com/150',
+  },
+  {
+    id: 4,
+    name: 'David',
+    isOnline: false,
+    userImage: 'https://via.placeholder.com/150',
+  },
+  {
+    id: 5,
+    name: 'Eve',
+    isOnline: true,
+    userImage: 'https://via.placeholder.com/150',
+  },
+  {
+    id: 6,
+    name: 'Frank',
+    isOnline: false,
+    userImage: 'https://via.placeholder.com/150',
+  },
+  {
+    id: 7,
+    name: 'Grace',
+    isOnline: true,
+    userImage: 'https://via.placeholder.com/150',
+  },
+];
+
+const UserListPage = () => {
+  const isOnlineUser = UserListPageDummyData.filter(user => user.isOnline);
+  const isOfflineUser = UserListPageDummyData.filter(user => !user.isOnline);
+
+  return (
+    <>
+      <div className='h-[40px] border-b border-gray-accent2 text-white'>
+        TobBar자리
+      </div>
+      <div className='flex grow flex-col gap-4 p-4'>
+        <div className='flex flex-col gap-2'>
+          <span className='text-gray-accent1'>{`온라인-${isOnlineUser.length}`}</span>
+          <UserList users={isOnlineUser} />
+        </div>
+        <div className='flex flex-col gap-2'>
+          <span className='text-gray-accent2'>{`오프라인-${isOfflineUser.length}`}</span>
+          <UserList users={isOfflineUser} />
+        </div>
+      </div>
+      <GNB />
+    </>
+  );
+};
+
+export default UserListPage;

--- a/src/components/ui/Drawer.tsx
+++ b/src/components/ui/Drawer.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import * as React from 'react';
+import { useEffect, useState } from 'react';
+
+import { Drawer as DrawerPrimitive } from 'vaul';
+
+import { cn } from '@/src/utils/cn';
+
+const Drawer = ({
+  shouldScaleBackground = true,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) => (
+  <DrawerPrimitive.Root
+    shouldScaleBackground={shouldScaleBackground}
+    {...props}
+  />
+);
+Drawer.displayName = 'Drawer';
+
+const DrawerTrigger = DrawerPrimitive.Trigger;
+
+const DrawerPortal = DrawerPrimitive.Portal;
+
+const DrawerClose = DrawerPrimitive.Close;
+
+const DrawerOverlay = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Overlay
+    ref={ref}
+    className={cn('fixed inset-0 z-50 bg-black/80', className)}
+    {...props}
+  />
+));
+DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName;
+
+const DrawerContent = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Content>,
+  React.ComponentProps<typeof DrawerPrimitive.Content>
+>(({ className, children, ...props }, ref) => {
+  const [container, setContainer] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    setContainer(document.getElementById('layout-Root'));
+  }, []);
+
+  return (
+    <DrawerPortal container={container}>
+      <DrawerOverlay />
+      <DrawerPrimitive.Content
+        ref={ref}
+        className={cn(
+          'bg-background fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border',
+          className,
+        )}
+        {...props}
+      >
+        <div className='bg-muted mx-auto mt-4 h-2 w-[100px] rounded-full' />
+        {children}
+      </DrawerPrimitive.Content>
+    </DrawerPortal>
+  );
+});
+DrawerContent.displayName = 'DrawerContent';
+
+const DrawerHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn('grid gap-1.5 p-4 text-center sm:text-left', className)}
+    {...props}
+  />
+);
+DrawerHeader.displayName = 'DrawerHeader';
+
+const DrawerFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn('mt-auto flex flex-col gap-2 p-4', className)}
+    {...props}
+  />
+);
+DrawerFooter.displayName = 'DrawerFooter';
+
+const DrawerTitle = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Title
+    ref={ref}
+    className={cn(
+      'text-lg font-semibold leading-none tracking-tight',
+      className,
+    )}
+    {...props}
+  />
+));
+DrawerTitle.displayName = DrawerPrimitive.Title.displayName;
+
+const DrawerDescription = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Description
+    ref={ref}
+    className={cn('text-muted-foreground text-sm', className)}
+    {...props}
+  />
+));
+DrawerDescription.displayName = DrawerPrimitive.Description.displayName;
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+};

--- a/src/components/ui/Drawer.tsx
+++ b/src/components/ui/Drawer.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import * as React from 'react';
 import {
   ComponentProps,
   ComponentPropsWithoutRef,

--- a/src/components/ui/Drawer.tsx
+++ b/src/components/ui/Drawer.tsx
@@ -1,7 +1,15 @@
 'use client';
 
 import * as React from 'react';
-import { useEffect, useState } from 'react';
+import {
+  ComponentProps,
+  ComponentPropsWithoutRef,
+  ElementRef,
+  HTMLAttributes,
+  forwardRef,
+  useEffect,
+  useState,
+} from 'react';
 
 import { Drawer as DrawerPrimitive } from 'vaul';
 
@@ -24,9 +32,9 @@ const DrawerPortal = DrawerPrimitive.Portal;
 
 const DrawerClose = DrawerPrimitive.Close;
 
-const DrawerOverlay = React.forwardRef<
-  React.ElementRef<typeof DrawerPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
+const DrawerOverlay = forwardRef<
+  ElementRef<typeof DrawerPrimitive.Overlay>,
+  ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
   <DrawerPrimitive.Overlay
     ref={ref}
@@ -36,9 +44,9 @@ const DrawerOverlay = React.forwardRef<
 ));
 DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName;
 
-const DrawerContent = React.forwardRef<
-  React.ElementRef<typeof DrawerPrimitive.Content>,
-  React.ComponentProps<typeof DrawerPrimitive.Content>
+const DrawerContent = forwardRef<
+  ElementRef<typeof DrawerPrimitive.Content>,
+  ComponentProps<typeof DrawerPrimitive.Content>
 >(({ className, children, ...props }, ref) => {
   const [container, setContainer] = useState<HTMLElement | null>(null);
 
@@ -68,7 +76,7 @@ DrawerContent.displayName = 'DrawerContent';
 const DrawerHeader = ({
   className,
   ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
+}: HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn('grid gap-1.5 p-4 text-center sm:text-left', className)}
     {...props}
@@ -79,7 +87,7 @@ DrawerHeader.displayName = 'DrawerHeader';
 const DrawerFooter = ({
   className,
   ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
+}: HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn('mt-auto flex flex-col gap-2 p-4', className)}
     {...props}
@@ -87,9 +95,9 @@ const DrawerFooter = ({
 );
 DrawerFooter.displayName = 'DrawerFooter';
 
-const DrawerTitle = React.forwardRef<
-  React.ElementRef<typeof DrawerPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
+const DrawerTitle = forwardRef<
+  ElementRef<typeof DrawerPrimitive.Title>,
+  ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
 >(({ className, ...props }, ref) => (
   <DrawerPrimitive.Title
     ref={ref}
@@ -102,9 +110,9 @@ const DrawerTitle = React.forwardRef<
 ));
 DrawerTitle.displayName = DrawerPrimitive.Title.displayName;
 
-const DrawerDescription = React.forwardRef<
-  React.ElementRef<typeof DrawerPrimitive.Description>,
-  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
+const DrawerDescription = forwardRef<
+  ElementRef<typeof DrawerPrimitive.Description>,
+  ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
 >(({ className, ...props }, ref) => (
   <DrawerPrimitive.Description
     ref={ref}

--- a/src/stories/decorator.tsx
+++ b/src/stories/decorator.tsx
@@ -1,7 +1,10 @@
 import { type Decorator } from '@storybook/react';
 
 export const PageLayoutDecorator: Decorator = Story => (
-  <div className='relative flex h-[844px] w-full min-w-[350px] max-w-[450px] shrink-0 flex-col items-center justify-center shadow-xl'>
+  <div
+    id='layout-Root'
+    className='relative flex h-[844px] w-full min-w-[350px] max-w-[450px] shrink-0 flex-col items-center justify-center shadow-xl'
+  >
     <div className='w-full grow bg-dark-accent1 p-4 text-white'>
       <Story />
     </div>

--- a/src/stories/pages/users.stories.tsx
+++ b/src/stories/pages/users.stories.tsx
@@ -1,0 +1,14 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import UsersPage from '@/src/app/users/page';
+import { PageLayoutDecorator } from '@/src/stories/decorator';
+
+const meta = {
+  title: 'pages/UsersPage',
+  decorators: [PageLayoutDecorator],
+  component: UsersPage,
+} satisfies Meta<typeof UsersPage>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};


### PR DESCRIPTION
## 💬 Issue Number

> closes #33

## 🤷‍♂️ Description

> 작업 내용에 대한 설명
* 유저 목록 UI 구현
* Shadcn Drawer 구현

## 📷 Screenshots

> 작업 결과물

https://github.com/nodak-v2/Nodak-FE/assets/102784200/67161b65-6296-412b-997d-6284584aefdf

## 👻 Good Function

> 팀원에게 공유하고 싶은 함수나 코드 일부

## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?

## 📒 Remarks

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점 특이사항
* 현재 스토리북에 Drawer의 container가 정상적으로 렌더링 되지 않는 오류가 있어서 스토리북을 만들지 못했습니다.
* Drawer내부의 버튼을 다르게 렌더링 해야하는데, 본인임을 확인할 수 있는 API 필드가 필요할 것으로 예상됩니다.
* 본인조회 / 타인조회에 따른 버튼을 다르게 렌더링 해야 할 것 같습니다.

### use client
* 페이지단위에서는 서버 컴포넌트로 동작합니다.
* 버튼에 `onClick`이벤트를 나중에 달아줘야해서 별도의 컴포넌트로 분리했습니다. 해당컴포넌트는 추후에 RCC(React Client Component)로 사용될 예정입니다.