### PR TITLE
[#75] Feat: 결과 페이지 api 연결

### DIFF
--- a/src/apis/post.ts
+++ b/src/apis/post.ts
@@ -73,11 +73,17 @@ export const getPostDetail = async (postId: string) => {
 export const createLike = async (postId: string) => {
   await fetch(`${BASE_URL}/posts/${postId}/stars`, {
     method: 'post',
+    headers: {
+      Authorization: TEST_TOKEN || '',
+    },
   });
 };
 
 export const deleteLike = async (postId: string) => {
   await fetch(`${BASE_URL}/posts/${postId}/stars`, {
     method: 'delete',
+    headers: {
+      Authorization: TEST_TOKEN || '',
+    },
   });
 };

--- a/src/apis/vote.ts
+++ b/src/apis/vote.ts
@@ -38,6 +38,9 @@ export const doVote = async (voteId: number, optionSeq: number) => {
     `${process.env.NEXT_PUBLIC_URL}/votes/${voteId}?option=${optionSeq}`,
     {
       method: 'post',
+      headers: {
+        Authorization: TEST_TOKEN || '',
+      },
     },
   );
 };


### PR DESCRIPTION
## 💬 Issue Number

> closes #75 

투표 하기와 좋아요 하기 각각에,
실제 200대 api 응답이 오도록 임시 헤더를 추가 했습니다.

## 🤷‍♂️ Description

> 작업 내용에 대한 설명

nodak 명세서에 명시된 임시 authorization token 인 TEST_TOKEN 을 fetch headers 에 포함시켜,
인증완료되게 하였습니다.

게시글 가져오기 API 응답에서 투표 옵션 정보가 누락된 상황입니다. 그래서 현재는 투표 결과 가져오기 API에서 투표 옵션을 가져오고 있습니다. 그러나 투표 결과 가져오기 API는 authorization 헤더, 즉 토큰이 있어야만 응답을 반환하기 때문에 원래 의도했던 흐름대로 진행되지 않습니다.

원래 흐름은 사용자가 투표하기를 누르면 인증 여부에 따라 로그인 리디렉션 또는 투표 결과 페이지로 이동하는 것이었지만, 현재는 페이지에 들어갈 때부터 로그인 리디렉션이 필요할 수 있는 상황입니다.

이 문제를 해결하기 위해 백엔드 팀과 소통하여 개선 방안을 논의한 후, 관련 PR을 올리겠습니다.

## 📷 Screenshots

![Create Next App - Chrome 2024-05-24 09-53-15](https://github.com/nodak-v2/Nodak-FE/assets/137467530/39e73046-f9a9-4e7b-bbc9-974c6fa1a20a)

> 작업 결과물

## 👻 Good Function

> 팀원에게 공유하고 싶은 함수나 코드 일부

## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?

## 📒 Remarks

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점 특이사항
