### PR TITLE
[#173] Feat: 유저, 게시글 페이지의 navMore 기능 추가

### DIFF
--- a/src/apis/postDetail.ts
+++ b/src/apis/postDetail.ts
@@ -49,7 +49,7 @@ export const useDeletePostDetailAPI = (postId: string) => {
     onMutate: async () => {
       router.push('/');
     },
-    onSettled: () => {
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['postList'] });
       queryClient.invalidateQueries({ queryKey: ['posts', postId] });
     },

--- a/src/apis/postDetail.ts
+++ b/src/apis/postDetail.ts
@@ -3,7 +3,6 @@ import {
   useQueryClient,
   useSuspenseQuery,
 } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
 
 import { api } from './core';
 
@@ -42,13 +41,9 @@ const deletePostDetail = (postId: string) => {
 
 export const useDeletePostDetailAPI = (postId: string) => {
   const queryClient = useQueryClient();
-  const router = useRouter();
 
   return useMutation({
     mutationFn: () => deletePostDetail(postId),
-    onMutate: async () => {
-      router.push('/');
-    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['postList'] });
       queryClient.invalidateQueries({ queryKey: ['posts', postId] });

--- a/src/apis/postDetail.ts
+++ b/src/apis/postDetail.ts
@@ -1,4 +1,9 @@
-import { useSuspenseQuery } from '@tanstack/react-query';
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
 
 import { api } from './core';
 
@@ -27,4 +32,26 @@ export const useGetPostDetailAPI = (postId: string) => {
   });
 
   return data.body;
+};
+
+const deletePostDetail = (postId: string) => {
+  return api.delete({
+    url: `/posts/${postId}`,
+  });
+};
+
+export const useDeletePostDetailAPI = (postId: string) => {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  return useMutation({
+    mutationFn: () => deletePostDetail(postId),
+    onMutate: async () => {
+      router.push('/');
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['postList'] });
+      queryClient.invalidateQueries({ queryKey: ['posts', postId] });
+    },
+  });
 };

--- a/src/app/(post)/result/[postId]/_components/CommentList/CommentItem/CommentItemMenu/CommentReplyItemMenu.tsx
+++ b/src/app/(post)/result/[postId]/_components/CommentList/CommentItem/CommentItemMenu/CommentReplyItemMenu.tsx
@@ -1,8 +1,9 @@
 import { useParams, useRouter } from 'next/navigation';
 
 import { useDeleteReplyCommentAPI } from '@/src/apis/reply';
-import CommentItemMenu from '@/src/app/(post)/result/[postId]/_components/CommentList/CommentItem/CommentItemMenu';
+import Icon from '@/src/components/Icon';
 import ConfirmationModal from '@/src/components/Modal/ConfirmationModal';
+import MoreMenu from '@/src/components/MoreMenu';
 import useModal from '@/src/hooks/useModal';
 
 interface CommentReplyItemMenuProps {
@@ -35,17 +36,14 @@ const CommentReplyItemMenu = ({
 
   return (
     <>
-      <CommentItemMenu>
+      <MoreMenu Icon={<Icon id='more-square' aria-label='댓글 더보기 메뉴' />}>
         {isOwnComment && (
-          <CommentItemMenu.Item label='삭제하기' onSelect={openDeleteModal} />
+          <MoreMenu.Item label='삭제하기' onSelect={openDeleteModal} />
         )}
         {!isOwnComment && (
-          <CommentItemMenu.Item
-            label='신고하기'
-            onSelect={handleReportComment}
-          />
+          <MoreMenu.Item label='신고하기' onSelect={handleReportComment} />
         )}
-      </CommentItemMenu>
+      </MoreMenu>
       <ConfirmationModal
         isShow={isDeleteModalOpen}
         description='삭제하시겠습니까?'

--- a/src/app/(post)/result/[postId]/_components/CommentList/CommentItem/CommentItemMenu/CommentRootItemMenu.tsx
+++ b/src/app/(post)/result/[postId]/_components/CommentList/CommentItem/CommentItemMenu/CommentRootItemMenu.tsx
@@ -1,8 +1,9 @@
 import { useParams, useRouter } from 'next/navigation';
 
 import { useDeleteCommentAPI } from '@/src/apis/comments';
-import CommentItemMenu from '@/src/app/(post)/result/[postId]/_components/CommentList/CommentItem/CommentItemMenu';
+import Icon from '@/src/components/Icon';
 import ConfirmationModal from '@/src/components/Modal/ConfirmationModal';
+import MoreMenu from '@/src/components/MoreMenu';
 import useModal from '@/src/hooks/useModal';
 
 interface CommentRootItemMenuProps {
@@ -43,24 +44,18 @@ const CommentRootItemMenu = ({
 
   return (
     <>
-      <CommentItemMenu>
-        <CommentItemMenu.Item label='답글달기' onSelect={handleReplyComment} />
+      <MoreMenu Icon={<Icon id='more-square' aria-label='댓글 더보기 메뉴' />}>
+        <MoreMenu.Item label='답글달기' onSelect={handleReplyComment} />
         {isOwnComment && (
           <>
-            <CommentItemMenu.Item
-              label='수정하기'
-              onSelect={handleEditComment}
-            />
-            <CommentItemMenu.Item label='삭제하기' onSelect={openDeleteModal} />
+            <MoreMenu.Item label='수정하기' onSelect={handleEditComment} />
+            <MoreMenu.Item label='삭제하기' onSelect={openDeleteModal} />
           </>
         )}
         {!isOwnComment && (
-          <CommentItemMenu.Item
-            label='신고하기'
-            onSelect={handleReportComment}
-          />
+          <MoreMenu.Item label='신고하기' onSelect={handleReportComment} />
         )}
-      </CommentItemMenu>
+      </MoreMenu>
 
       <ConfirmationModal
         isShow={isDeleteModalOpen}

--- a/src/app/(post)/result/[postId]/_components/PostDetailNavMore/index.tsx
+++ b/src/app/(post)/result/[postId]/_components/PostDetailNavMore/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 
 import {
   useDeletePostDetailAPI,
@@ -13,6 +13,7 @@ import TopBar from '@/src/components/Topbar';
 import useModal from '@/src/hooks/useModal';
 
 const PostDetailNavMore = () => {
+  const router = useRouter();
   const { postId } = useParams() as { postId: string };
   const { isAuthor } = useGetPostDetailAPI(postId);
   const { mutateAsync: deletePost } = useDeletePostDetailAPI(postId);
@@ -20,8 +21,12 @@ const PostDetailNavMore = () => {
   const { isOpen, open, close } = useModal();
 
   const handleDeletePost = async () => {
-    await deletePost();
-    Toast.default('게시글이 삭제되었습니다.');
+    await deletePost(undefined, {
+      onSuccess: () => {
+        router.push('/');
+        Toast.default('게시글이 삭제되었습니다.');
+      },
+    });
   };
 
   return (

--- a/src/app/(post)/result/[postId]/_components/PostDetailNavMore/index.tsx
+++ b/src/app/(post)/result/[postId]/_components/PostDetailNavMore/index.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+
+import {
+  useDeletePostDetailAPI,
+  useGetPostDetailAPI,
+} from '@/src/apis/postDetail';
+import ConfirmationModal from '@/src/components/Modal/ConfirmationModal';
+import Toast from '@/src/components/Toast';
+import TopBar from '@/src/components/Topbar';
+import useModal from '@/src/hooks/useModal';
+
+const PostDetailNavMore = () => {
+  const { postId } = useParams() as { postId: string };
+  const { isAuthor } = useGetPostDetailAPI(postId);
+  const { mutateAsync: deletePost } = useDeletePostDetailAPI(postId);
+
+  const { isOpen, open, close } = useModal();
+
+  const handleDeletePost = async () => {
+    await deletePost();
+    Toast.default('게시글이 삭제되었습니다.');
+  };
+
+  return (
+    <>
+      <TopBar.NavMore>
+        {isAuthor ? (
+          <TopBar.NavMore.Item>
+            <button onClick={open}>삭제하기</button>
+          </TopBar.NavMore.Item>
+        ) : (
+          <TopBar.NavMore.Item>
+            <Link href='/report'>신고하기</Link>
+          </TopBar.NavMore.Item>
+        )}
+      </TopBar.NavMore>
+
+      <ConfirmationModal
+        description='정말로 삭제하시겠습니까?'
+        onConfirm={handleDeletePost}
+        isShow={isOpen}
+        onClose={close}
+      />
+    </>
+  );
+};
+
+export default PostDetailNavMore;

--- a/src/app/(post)/result/[postId]/layout.tsx
+++ b/src/app/(post)/result/[postId]/layout.tsx
@@ -1,58 +1,20 @@
-'use client';
-
 import { PropsWithChildren, Suspense } from 'react';
 
-import Link from 'next/link';
-import { useParams } from 'next/navigation';
-
-import {
-  useDeletePostDetailAPI,
-  useGetPostDetailAPI,
-} from '@/src/apis/postDetail';
-import ConfirmationModal from '@/src/components/Modal/ConfirmationModal';
+import PostDetailNavMore from '@/src/app/(post)/result/[postId]/_components/PostDetailNavMore';
 import Spinner from '@/src/components/Spinner';
-import Toast from '@/src/components/Toast';
 import TopBar from '@/src/components/Topbar';
-import useModal from '@/src/hooks/useModal';
 import { getGenerateMetadata } from '@/src/utils/getGenerateMetadata';
 
 export const generateMetadata = getGenerateMetadata();
 
 const PostDetailLayout = ({ children }: PropsWithChildren) => {
-  const { postId } = useParams() as { postId: string };
-  const { isAuthor } = useGetPostDetailAPI(postId);
-  const { mutateAsync: deletePost } = useDeletePostDetailAPI(postId);
-
-  const { isOpen, open, close } = useModal();
-
-  const handleDeletePost = async () => {
-    await deletePost();
-    Toast.default('게시글이 삭제되었습니다.');
-  };
-
   return (
     <>
       <TopBar.Container>
         <TopBar.BackButton href='/' />
         <TopBar.Title>투표 글</TopBar.Title>
-        <TopBar.NavMore>
-          {isAuthor ? (
-            <TopBar.NavMore.Item>
-              <button onClick={open}>삭제하기</button>
-            </TopBar.NavMore.Item>
-          ) : (
-            <TopBar.NavMore.Item>
-              <Link href='/report'>신고하기</Link>
-            </TopBar.NavMore.Item>
-          )}
-        </TopBar.NavMore>
+        <PostDetailNavMore />
       </TopBar.Container>
-      <ConfirmationModal
-        description='정말로 삭제하시겠습니까?'
-        onConfirm={handleDeletePost}
-        isShow={isOpen}
-        onClose={close}
-      />
       <Suspense fallback={<Spinner text='게시글 정보를 불러오는 중 입니다.' />}>
         {children}
       </Suspense>

--- a/src/app/(post)/result/[postId]/layout.tsx
+++ b/src/app/(post)/result/[postId]/layout.tsx
@@ -1,23 +1,49 @@
 import { PropsWithChildren, Suspense } from 'react';
 
 import Link from 'next/link';
+import { useParams } from 'next/navigation';
 
+import { useGetPostDetailAPI } from '@/src/apis/postDetail';
+import ConfirmationModal from '@/src/components/Modal/ConfirmationModal';
 import Spinner from '@/src/components/Spinner';
 import TopBar from '@/src/components/Topbar';
+import useModal from '@/src/hooks/useModal';
 import { getGenerateMetadata } from '@/src/utils/getGenerateMetadata';
 
 export const generateMetadata = getGenerateMetadata();
 
 const PostDetailLayout = ({ children }: PropsWithChildren) => {
+  const { postId } = useParams() as { postId: string };
+  const { isAuthor } = useGetPostDetailAPI(postId);
+
+  const { isOpen, open, close } = useModal();
+
+  const handleDeletePost = () => {
+    if (isAuthor) {
+      console.log('delete post');
+    }
+  };
+
   return (
     <>
       <TopBar.Container>
         <TopBar.BackButton href='/' />
         <TopBar.Title>투표 글</TopBar.Title>
         <TopBar.NavMore>
-          <Link href='/report'>신고하기</Link>
+          <TopBar.NavMore.Item>
+            <Link href='/report'>신고하기</Link>
+          </TopBar.NavMore.Item>
+          <TopBar.NavMore.Item>
+            <button onClick={open}>삭제하기</button>
+          </TopBar.NavMore.Item>
         </TopBar.NavMore>
       </TopBar.Container>
+      <ConfirmationModal
+        description='정말로 삭제하시겠습니까?'
+        onConfirm={handleDeletePost}
+        isShow={isOpen}
+        onClose={close}
+      />
       <Suspense fallback={<Spinner text='게시글 정보를 불러오는 중 입니다.' />}>
         {children}
       </Suspense>

--- a/src/app/(post)/result/[postId]/layout.tsx
+++ b/src/app/(post)/result/[postId]/layout.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/src/apis/postDetail';
 import ConfirmationModal from '@/src/components/Modal/ConfirmationModal';
 import Spinner from '@/src/components/Spinner';
+import Toast from '@/src/components/Toast';
 import TopBar from '@/src/components/Topbar';
 import useModal from '@/src/hooks/useModal';
 import { getGenerateMetadata } from '@/src/utils/getGenerateMetadata';
@@ -23,7 +24,8 @@ const PostDetailLayout = ({ children }: PropsWithChildren) => {
   const { isOpen, open, close } = useModal();
 
   const handleDeletePost = async () => {
-    deletePost();
+    await deletePost();
+    Toast.default('게시글이 삭제되었습니다.');
   };
 
   return (

--- a/src/app/(post)/result/[postId]/layout.tsx
+++ b/src/app/(post)/result/[postId]/layout.tsx
@@ -1,5 +1,7 @@
 import { PropsWithChildren, Suspense } from 'react';
 
+import Link from 'next/link';
+
 import Spinner from '@/src/components/Spinner';
 import TopBar from '@/src/components/Topbar';
 import { getGenerateMetadata } from '@/src/utils/getGenerateMetadata';
@@ -12,7 +14,9 @@ const PostDetailLayout = ({ children }: PropsWithChildren) => {
       <TopBar.Container>
         <TopBar.BackButton href='/' />
         <TopBar.Title>투표 글</TopBar.Title>
-        <TopBar.NavMore />
+        <TopBar.NavMore>
+          <Link href='/report'>신고하기</Link>
+        </TopBar.NavMore>
       </TopBar.Container>
       <Suspense fallback={<Spinner text='게시글 정보를 불러오는 중 입니다.' />}>
         {children}

--- a/src/app/(post)/result/[postId]/layout.tsx
+++ b/src/app/(post)/result/[postId]/layout.tsx
@@ -3,7 +3,10 @@ import { PropsWithChildren, Suspense } from 'react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 
-import { useGetPostDetailAPI } from '@/src/apis/postDetail';
+import {
+  useDeletePostDetailAPI,
+  useGetPostDetailAPI,
+} from '@/src/apis/postDetail';
 import ConfirmationModal from '@/src/components/Modal/ConfirmationModal';
 import Spinner from '@/src/components/Spinner';
 import TopBar from '@/src/components/Topbar';
@@ -15,13 +18,12 @@ export const generateMetadata = getGenerateMetadata();
 const PostDetailLayout = ({ children }: PropsWithChildren) => {
   const { postId } = useParams() as { postId: string };
   const { isAuthor } = useGetPostDetailAPI(postId);
+  const { mutateAsync: deletePost } = useDeletePostDetailAPI(postId);
 
   const { isOpen, open, close } = useModal();
 
-  const handleDeletePost = () => {
-    if (isAuthor) {
-      console.log('delete post');
-    }
+  const handleDeletePost = async () => {
+    deletePost();
   };
 
   return (
@@ -33,9 +35,11 @@ const PostDetailLayout = ({ children }: PropsWithChildren) => {
           <TopBar.NavMore.Item>
             <Link href='/report'>신고하기</Link>
           </TopBar.NavMore.Item>
-          <TopBar.NavMore.Item>
-            <button onClick={open}>삭제하기</button>
-          </TopBar.NavMore.Item>
+          {isAuthor && (
+            <TopBar.NavMore.Item>
+              <button onClick={open}>삭제하기</button>
+            </TopBar.NavMore.Item>
+          )}
         </TopBar.NavMore>
       </TopBar.Container>
       <ConfirmationModal

--- a/src/app/(post)/result/[postId]/layout.tsx
+++ b/src/app/(post)/result/[postId]/layout.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { PropsWithChildren, Suspense } from 'react';
 
 import Link from 'next/link';

--- a/src/app/(post)/result/[postId]/layout.tsx
+++ b/src/app/(post)/result/[postId]/layout.tsx
@@ -32,12 +32,13 @@ const PostDetailLayout = ({ children }: PropsWithChildren) => {
         <TopBar.BackButton href='/' />
         <TopBar.Title>투표 글</TopBar.Title>
         <TopBar.NavMore>
-          <TopBar.NavMore.Item>
-            <Link href='/report'>신고하기</Link>
-          </TopBar.NavMore.Item>
-          {isAuthor && (
+          {isAuthor ? (
             <TopBar.NavMore.Item>
               <button onClick={open}>삭제하기</button>
+            </TopBar.NavMore.Item>
+          ) : (
+            <TopBar.NavMore.Item>
+              <Link href='/report'>신고하기</Link>
             </TopBar.NavMore.Item>
           )}
         </TopBar.NavMore>

--- a/src/app/report/layout.tsx
+++ b/src/app/report/layout.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { PropsWithChildren } from 'react';
+
+import TopBar from '@/src/components/Topbar';
+
+const PostDetailLayout = ({ children }: PropsWithChildren) => {
+  return (
+    <>
+      <TopBar.Container>
+        <TopBar.BackButton href='/' />
+      </TopBar.Container>
+      {children}
+    </>
+  );
+};
+
+export default PostDetailLayout;

--- a/src/app/report/page.tsx
+++ b/src/app/report/page.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import Icon from '@/src/components/Icon';
+
+const ReportPage = () => {
+  const router = useRouter();
+
+  const handleNavigateToVote = () => {
+    router.push('/');
+  };
+
+  return (
+    <div className='font-h3-sm flex h-full grow flex-col items-center justify-center'>
+      <Icon id='warning' aria-label='오류 발생' size={64} />
+      <span className='font-h3-bold mt-3 text-gray-accent3'>
+        현재 개발 중인 기능입니다.
+      </span>
+      <span className='font-h3-bold text-gray-accent3'>
+        조금만 기다려 주세요.
+      </span>
+      <button
+        onClick={handleNavigateToVote}
+        className='text-h3-sm mt-[60px] flex w-40 items-center justify-center rounded-[28px] bg-primary px-6 py-3'
+      >
+        투표 둘러보기
+      </button>
+    </div>
+  );
+};
+
+export default ReportPage;

--- a/src/app/users/[userId]/layout.tsx
+++ b/src/app/users/[userId]/layout.tsx
@@ -1,16 +1,20 @@
 import { PropsWithChildren, Suspense } from 'react';
 
+import Link from 'next/link';
+
 import Spinner from '@/src/components/Spinner';
 import TopBar from '@/src/components/Topbar';
 
 const UserPageLayout = ({ children }: PropsWithChildren) => {
-  // TopBar 컴포넌트가 이전 PR이 머지되면 추가될 예정입니다.
   return (
     <Suspense fallback={<Spinner text='유저 정보를 불러오는 중 입니다.' />}>
       <TopBar.Container>
         <TopBar.BackButton href='/' />
         <TopBar.Title>프로필</TopBar.Title>
-        <TopBar.NavMore />
+        <TopBar.NavMore>
+          <Link href='/'>홈</Link>
+          <Link href='/report'>신고하기</Link>
+        </TopBar.NavMore>
       </TopBar.Container>
       {children}
     </Suspense>

--- a/src/app/users/[userId]/layout.tsx
+++ b/src/app/users/[userId]/layout.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { PropsWithChildren, Suspense } from 'react';
 
 import Link from 'next/link';
@@ -12,8 +14,9 @@ const UserPageLayout = ({ children }: PropsWithChildren) => {
         <TopBar.BackButton href='/' />
         <TopBar.Title>프로필</TopBar.Title>
         <TopBar.NavMore>
-          <Link href='/'>홈</Link>
-          <Link href='/report'>신고하기</Link>
+          <TopBar.NavMore.Item>
+            <Link href='/report'>신고하기</Link>
+          </TopBar.NavMore.Item>
         </TopBar.NavMore>
       </TopBar.Container>
       {children}

--- a/src/components/Modal/ConfirmationModal.tsx
+++ b/src/components/Modal/ConfirmationModal.tsx
@@ -14,6 +14,11 @@ const ConfirmationModal = ({
   onClose,
   onConfirm,
 }: ConfirmationModalProps) => {
+  const handleConfirm = () => {
+    onConfirm();
+    onClose();
+  };
+
   return (
     <Modal
       show={isShow}
@@ -32,7 +37,7 @@ const ConfirmationModal = ({
         <Button
           className='font-title-1-md w-full py-3'
           baseColor='primary'
-          onClick={onConfirm}
+          onClick={handleConfirm}
         >
           확인
         </Button>

--- a/src/components/MoreMenu/index.tsx
+++ b/src/components/MoreMenu/index.tsx
@@ -31,8 +31,16 @@ interface MoreMenuItemProps {
   onSelect?: () => void;
 }
 
-const MoreItem = ({ label, onSelect }: MoreMenuItemProps) => {
-  return <DropdownMenu.Item onSelect={onSelect}>{label}</DropdownMenu.Item>;
+const MoreItem = ({
+  label,
+  onSelect,
+  children,
+}: PropsWithChildren<MoreMenuItemProps>) => {
+  return (
+    <DropdownMenu.Item onSelect={onSelect}>
+      {children || label}
+    </DropdownMenu.Item>
+  );
 };
 
 MoreMenu.Item = MoreItem;

--- a/src/components/MoreMenu/index.tsx
+++ b/src/components/MoreMenu/index.tsx
@@ -2,14 +2,14 @@ import { PropsWithChildren } from 'react';
 
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 
-import Icon from '@/src/components/Icon';
+interface MoreMenuProps {
+  Icon: React.ReactNode;
+}
 
-const CommentItemMenu = ({ children }: PropsWithChildren) => {
+const MoreMenu = ({ Icon, children }: PropsWithChildren<MoreMenuProps>) => {
   return (
     <DropdownMenu.Root>
-      <DropdownMenu.Trigger>
-        <Icon id='more-square' aria-label='댓글 더보기 메뉴' />
-      </DropdownMenu.Trigger>
+      <DropdownMenu.Trigger>{Icon}</DropdownMenu.Trigger>
       <DropdownMenu.Portal>
         <DropdownMenu.Content
           collisionBoundary={document.querySelector('#layout-Root')}
@@ -24,14 +24,14 @@ const CommentItemMenu = ({ children }: PropsWithChildren) => {
   );
 };
 
-interface CommentItemMenuItemProps {
+interface MoreMenuItemProps {
   label: string;
   onSelect: () => void;
 }
 
-const CommentItem = ({ label, onSelect }: CommentItemMenuItemProps) => {
+const MoreItem = ({ label, onSelect }: MoreMenuItemProps) => {
   return <DropdownMenu.Item onSelect={onSelect}>{label}</DropdownMenu.Item>;
 };
 
-CommentItemMenu.Item = CommentItem;
-export default CommentItemMenu;
+MoreMenu.Item = MoreItem;
+export default MoreMenu;

--- a/src/components/MoreMenu/index.tsx
+++ b/src/components/MoreMenu/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { PropsWithChildren } from 'react';
 
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
@@ -25,8 +27,8 @@ const MoreMenu = ({ Icon, children }: PropsWithChildren<MoreMenuProps>) => {
 };
 
 interface MoreMenuItemProps {
-  label: string;
-  onSelect: () => void;
+  label?: string;
+  onSelect?: () => void;
 }
 
 const MoreItem = ({ label, onSelect }: MoreMenuItemProps) => {

--- a/src/components/Topbar/index.tsx
+++ b/src/components/Topbar/index.tsx
@@ -13,12 +13,13 @@ const Container = ({ children }: PropsWithChildren) => {
   );
 };
 
-// NavMore 컴포넌트는 MoreMenu 컴포넌트를 사용하여 구현합니다.
 const NavMore = ({ children }: PropsWithChildren) => (
   <MoreMenu Icon={<Icon id='nav-more' size={24} className='cursor-pointer' />}>
     {children}
   </MoreMenu>
 );
+
+NavMore.Item = MoreMenu.Item;
 
 const BackButton = ({ href }: { href: string }) => (
   <Link href={href}>

--- a/src/components/Topbar/index.tsx
+++ b/src/components/Topbar/index.tsx
@@ -3,6 +3,7 @@ import { PropsWithChildren } from 'react';
 import Link from 'next/link';
 
 import Icon from '@/src/components/Icon';
+import MoreMenu from '@/src/components/MoreMenu';
 
 const Container = ({ children }: PropsWithChildren) => {
   return (
@@ -12,8 +13,11 @@ const Container = ({ children }: PropsWithChildren) => {
   );
 };
 
-const NavMore = () => (
-  <Icon id='nav-more' size={24} className='cursor-pointer' />
+// NavMore 컴포넌트는 MoreMenu 컴포넌트를 사용하여 구현합니다.
+const NavMore = ({ children }: PropsWithChildren) => (
+  <MoreMenu Icon={<Icon id='nav-more' size={24} className='cursor-pointer' />}>
+    {children}
+  </MoreMenu>
 );
 
 const BackButton = ({ href }: { href: string }) => (


### PR DESCRIPTION
## 💬 Issue Number

> closes #173 

## 🤷‍♂️ Description

> 작업 내용에 대한 설명

유저 와 게시글 페이지의 더보기 옵션에 드롭다운 모달(삭제, 신고)을 추가하였습니다.

임시 신고페이지를 만들었습니다.
## 📷 Screenshots

> 작업 결과물

#### 게시글 상세페이지 (자신의 글)
![image](https://github.com/user-attachments/assets/b55e6b67-61ed-459f-92f4-ccdeb5b57110)

#### 게시글 상세페이지 (상대 글)
![image](https://github.com/user-attachments/assets/e1cba483-e1f9-4fa8-9d67-2893ae90decf)


#### 유저 페이지
![image](https://github.com/user-attachments/assets/5af33814-59b6-4edf-bc32-4556e69924dd)

#### 신고 페이지
![image](https://github.com/user-attachments/assets/0fb89369-c24f-4ed1-953a-a3286bd793fe)

## 👻 Good Function

> 팀원에게 공유하고 싶은 함수나 코드 일부

## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?

## 📒 Remarks

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점 특이사항
