### PR TITLE
[#184] Feat: 라우팅 인증 처리 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lodash": "^4.17.21",
     "next": "14.2.1",
     "next-pwa": "^5.6.0",
+    "path-to-regexp": "^7.1.0",
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.51.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ dependencies:
   next-pwa:
     specifier: ^5.6.0
     version: 5.6.0(@babel/core@7.24.4)(esbuild@0.20.2)(next@14.2.1)(webpack@5.91.0)
+  path-to-regexp:
+    specifier: ^7.1.0
+    version: 7.1.0
   react:
     specifier: ^18
     version: 18.2.0
@@ -9649,6 +9652,11 @@ packages:
   /path-to-regexp@6.2.2:
     resolution: {integrity: sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==}
     dev: true
+
+  /path-to-regexp@7.1.0:
+    resolution: {integrity: sha512-ZToe+MbUF4lBqk6dV8GKot4DKfzrxXsplOddH8zN3YK+qw9/McvP7+4ICjZvOne0jQhN4eJwHsX6tT0Ns19fvw==}
+    engines: {node: '>=16'}
+    dev: false
 
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}

--- a/src/app/AuthenticatedRoute.tsx
+++ b/src/app/AuthenticatedRoute.tsx
@@ -14,12 +14,8 @@ const AuthenticatedRoute = () => {
   const router = useRouter();
   const { login: isLogin } = useGetUserStatusAPI();
 
-  if (isLogin || pathToRegexp(redirectUrl).test(pathname)) {
-    return null;
-  }
-
   if (!isLogin && matchers.some(path => pathToRegexp(path).test(pathname))) {
-    router.push('/signin');
+    router.push(redirectUrl);
   }
 
   return null;

--- a/src/app/AuthenticatedRoute.tsx
+++ b/src/app/AuthenticatedRoute.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { usePathname, useRouter } from 'next/navigation';
+import { pathToRegexp } from 'path-to-regexp';
+
+import { useGetUserStatusAPI } from '@/src/apis/myInfo';
+
+const matchers = ['/users/profile/:path'];
+
+const redirectUrl = '/signin';
+
+const AuthenticatedRoute = () => {
+  const pathname = usePathname();
+  const router = useRouter();
+  const { login: isLogin } = useGetUserStatusAPI();
+
+  if (isLogin || pathToRegexp(redirectUrl).test(pathname)) {
+    return null;
+  }
+
+  if (!isLogin && matchers.some(path => pathToRegexp(path).test(pathname))) {
+    router.push('/signin');
+  }
+
+  return null;
+};
+
+export default AuthenticatedRoute;

--- a/src/app/AuthenticatedRoute.tsx
+++ b/src/app/AuthenticatedRoute.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { PropsWithChildren } from 'react';
+
 import { usePathname, useRouter } from 'next/navigation';
 import { pathToRegexp } from 'path-to-regexp';
 
@@ -9,16 +11,17 @@ const matchers = ['/users/profile/:path'];
 
 const redirectUrl = '/signin';
 
-const AuthenticatedRoute = () => {
+const AuthenticatedRoute = ({ children }: PropsWithChildren) => {
   const pathname = usePathname();
   const router = useRouter();
   const { login: isLogin } = useGetUserStatusAPI();
 
   if (!isLogin && matchers.some(path => pathToRegexp(path).test(pathname))) {
     router.push(redirectUrl);
+    return null;
   }
 
-  return null;
+  return <>{children}</>;
 };
 
 export default AuthenticatedRoute;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Viewport } from 'next';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 
+import AuthenticatedRoute from '@/src/app/AuthenticatedRoute';
 import GoogleAnalytics from '@/src/components/GoogleAnalystics';
 
 import Introduction from '../components/Introduction';
@@ -42,6 +43,7 @@ const RootLayout = ({
                 className='relative flex h-full max-h-[950px] min-h-[600px] w-full min-w-[350px] max-w-[450px] shrink-0 flex-col bg-background text-white shadow-xl'
               >
                 {children}
+                <AuthenticatedRoute />
                 <ToastContainer className='absolute bottom-[103px] flex flex-col items-center justify-center' />
               </div>
             </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -42,8 +42,7 @@ const RootLayout = ({
                 id='layout-Root'
                 className='relative flex h-full max-h-[950px] min-h-[600px] w-full min-w-[350px] max-w-[450px] shrink-0 flex-col bg-background text-white shadow-xl'
               >
-                {children}
-                <AuthenticatedRoute />
+                <AuthenticatedRoute>{children}</AuthenticatedRoute>
                 <ToastContainer className='absolute bottom-[103px] flex flex-col items-center justify-center' />
               </div>
             </div>

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,7 @@
+import Spinner from '@/src/components/Spinner';
+
+const Loading = () => {
+  return <Spinner text='로딩중...' />;
+};
+
+export default Loading;


### PR DESCRIPTION
## 💬 Issue Number

> closes #184 

## 🤷‍♂️ Description

> 작업 내용에 대한 설명

특정 페이지로 이동시 미인증 사용자일시 login 페이지로 이동시키는 컴포넌트를 구현하였습니다.

matcher 변수에 url 을 추가해주시면 다른 페이지들도 적용됩니다.

- url path 를 regex 로 변환시키기위한 라이브러리를 추가하였습니다.
## 📷 Screenshots

> 작업 결과물
![Arc 2024-07-17 13-54-39](https://github.com/user-attachments/assets/abc97a37-831f-428f-a64f-3efe9fe2f072)

## 👻 Good Function

> 팀원에게 공유하고 싶은 함수나 코드 일부

## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?

## 📒 Remarks

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점 특이사항
