### PR TITLE
[#195] Fix: 팔로워 팔로이 관련 수정사항

### DIFF
--- a/src/apis/follow.ts
+++ b/src/apis/follow.ts
@@ -65,7 +65,7 @@ const deleteFollow = (userId: string) => {
   });
 };
 
-export const usePostFollowAPI = (userId: string) => {
+export const usePostFollowAPI = (userId: string, myId: string) => {
   const queryClient = useQueryClient();
 
   const { mutateAsync } = useMutation({
@@ -75,10 +75,10 @@ export const usePostFollowAPI = (userId: string) => {
         queryKey: ['profile', userId],
       });
       queryClient.invalidateQueries({
-        queryKey: ['followees', userId],
+        queryKey: ['followees', myId],
       });
       queryClient.invalidateQueries({
-        queryKey: ['followers', userId],
+        queryKey: ['followers', myId],
       });
     },
   });
@@ -86,7 +86,7 @@ export const usePostFollowAPI = (userId: string) => {
   return mutateAsync;
 };
 
-export const useDeleteFollowAPI = (userId: string) => {
+export const useDeleteFollowAPI = (userId: string, myId: string) => {
   const queryClient = useQueryClient();
 
   const { mutateAsync } = useMutation({
@@ -96,10 +96,10 @@ export const useDeleteFollowAPI = (userId: string) => {
         queryKey: ['profile', userId],
       });
       queryClient.invalidateQueries({
-        queryKey: ['followees', userId],
+        queryKey: ['followees', myId],
       });
       queryClient.invalidateQueries({
-        queryKey: ['followers', userId],
+        queryKey: ['followers', myId],
       });
     },
   });

--- a/src/apis/follow.ts
+++ b/src/apis/follow.ts
@@ -77,6 +77,9 @@ export const usePostFollowAPI = (userId: string) => {
       queryClient.invalidateQueries({
         queryKey: ['followees', userId],
       });
+      queryClient.invalidateQueries({
+        queryKey: ['followers', userId],
+      });
     },
   });
 
@@ -94,6 +97,9 @@ export const useDeleteFollowAPI = (userId: string) => {
       });
       queryClient.invalidateQueries({
         queryKey: ['followees', userId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['followers', userId],
       });
     },
   });

--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 
+import { BASE_URL } from '@/src/apis/constants';
 import Icon from '@/src/components/Icon';
 import TopBar from '@/src/components/Topbar';
 
@@ -19,7 +20,7 @@ const Signin = () => {
         <span className='font-h3-sm'>{SLOGAN}</span>
       </div>
       <div className='sticky mb-[60px] h-[44px] min-w-full'>
-        <Link href='https://api.picky-pick.com/oauth2/authorization/kakao'>
+        <Link href={`${BASE_URL}/oauth2/authorization/kakao`}>
           <Image
             src='/picky/kakao.svg'
             alt='kakao'

--- a/src/app/social/_components/FollowButtons/FollowButton.tsx
+++ b/src/app/social/_components/FollowButtons/FollowButton.tsx
@@ -1,4 +1,5 @@
 import { usePostFollowAPI } from '@/src/apis/follow';
+import { useGetUserStatusAPI } from '@/src/apis/myInfo';
 import Button from '@/src/components/Button/Button';
 
 interface FollowButtonProps {
@@ -6,7 +7,8 @@ interface FollowButtonProps {
 }
 
 const FollowButton = ({ userId }: FollowButtonProps) => {
-  const postFollow = usePostFollowAPI(userId.toString());
+  const { userId: myId } = useGetUserStatusAPI();
+  const postFollow = usePostFollowAPI(userId.toString(), myId.toString());
 
   const handleFollow = () => postFollow();
 

--- a/src/app/social/_components/FollowButtons/UnFollowButton.tsx
+++ b/src/app/social/_components/FollowButtons/UnFollowButton.tsx
@@ -1,4 +1,5 @@
 import { useDeleteFollowAPI } from '@/src/apis/follow';
+import { useGetUserStatusAPI } from '@/src/apis/myInfo';
 import Button from '@/src/components/Button/Button';
 import ConfirmationModal from '@/src/components/Modal/ConfirmationModal';
 import useModal from '@/src/hooks/useModal';
@@ -8,7 +9,8 @@ interface FollowButtonProps {
 }
 
 const UnFollowButton = ({ userId }: FollowButtonProps) => {
-  const deleteFollow = useDeleteFollowAPI(userId.toString());
+  const { userId: myId } = useGetUserStatusAPI();
+  const deleteFollow = useDeleteFollowAPI(userId.toString(), myId.toString());
   const { isOpen, open, close } = useModal();
 
   const handleUnFollow = () => {

--- a/src/app/users/[userId]/hooks/useFollow.ts
+++ b/src/app/users/[userId]/hooks/useFollow.ts
@@ -5,8 +5,9 @@ import { useGetUserStatusAPI } from '@/src/apis/myInfo';
 import Toast from '@/src/components/Toast';
 
 export const useFollow = (userId: string) => {
-  const postFollow = usePostFollowAPI(userId);
-  const deleteFollow = useDeleteFollowAPI(userId);
+  const { userId: myId } = useGetUserStatusAPI();
+  const postFollow = usePostFollowAPI(userId, myId.toString());
+  const deleteFollow = useDeleteFollowAPI(userId, myId.toString());
 
   const { login: isLogin } = useGetUserStatusAPI();
   const router = useRouter();

--- a/src/app/users/_components/ProfileBlock.tsx
+++ b/src/app/users/_components/ProfileBlock.tsx
@@ -8,6 +8,7 @@ import { useGetUserStatusAPI } from '@/src/apis/myInfo';
 import { useGetProfileAPI } from '@/src/apis/profile';
 import ConfirmationModal from '@/src/components/Modal/ConfirmationModal';
 import useModal from '@/src/hooks/useModal';
+import { cn } from '@/src/utils/cn';
 
 import { useFollow } from '../[userId]/hooks/useFollow';
 
@@ -115,11 +116,23 @@ const ProfileBlock = () => {
               <span className='font-text-3-rg text-gray-accent4'>작성글</span>
               <span className='font-title-2-sm'>{postCount}</span>
             </div>
-            <Link className='flex items-center gap-1' href={followersPath}>
+            <Link
+              className={cn(
+                'flex items-center gap-1',
+                followerCount === 0 && 'pointer-events-none',
+              )}
+              href={followersPath}
+            >
               <span className='font-text-3-rg text-gray-accent4'>팔로워</span>
               <span className='font-title-2-sm'>{followerCount}</span>
             </Link>
-            <Link className='flex items-center gap-1' href={followeesPath}>
+            <Link
+              className={cn(
+                'flex items-center gap-1',
+                followeeCount === 0 && 'pointer-events-none',
+              )}
+              href={followeesPath}
+            >
               <span className='font-text-3-rg text-gray-accent4'>팔로잉</span>
               <span className='font-title-2-sm'>{followeeCount}</span>
             </Link>


### PR DESCRIPTION
## 💬 Issue Number

> closes #195 

## 🤷‍♂️ Description

> 작업 내용에 대한 설명

- 프로필 페이지의 팔로워, 팔로이 수가 0일경우 navigate 가 되지않도록 수정하였습니다.
- 팔로워 팔로이 페이지의 캐시 초기화가 안되는 문제 수정하였습니다.
## 📷 Screenshots

> 작업 결과물

#### 팔로로워 팔로이 캐시 문제 수정

https://github.com/user-attachments/assets/019537e5-a11d-4716-83dd-22ab0e0666e1
## 👻 Good Function

> 팀원에게 공유하고 싶은 함수나 코드 일부

## 📋 Check List

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?

## 📒 Remarks

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점 특이사항
